### PR TITLE
Fix SaveManager yielding on new players & minor improvments

### DIFF
--- a/src/ReplicatedStorage/Modules/Utils/PlayerUtils.luau
+++ b/src/ReplicatedStorage/Modules/Utils/PlayerUtils.luau
@@ -34,6 +34,7 @@ function PlayerUtils.ObservePlayers(callback: (player: Player, playerJanitor: Ja
 	for _, player in Players:GetPlayers() do
 		task.spawn(onNewPlayer, player)
 	end
+    
 	mainJanitor:Add(Players.PlayerAdded:Connect(onNewPlayer))
 	mainJanitor:Add(Players.PlayerRemoving:Connect(function(player: Player)
 		mainJanitor:Remove(player)

--- a/src/ServerScriptService/Managers/SaveManager/DataStoreKey.model.json
+++ b/src/ServerScriptService/Managers/SaveManager/DataStoreKey.model.json
@@ -1,0 +1,7 @@
+{
+    "className": "StringValue",
+    "properties": {
+        "Value": "DATA_STORE_KEY_HERE"
+    }
+
+}

--- a/src/ServerScriptService/Managers/SaveManager/DataStoreRef.model.json
+++ b/src/ServerScriptService/Managers/SaveManager/DataStoreRef.model.json
@@ -1,0 +1,7 @@
+{
+    "className": "StringValue",
+    "properties": {
+        "Value": "DATA_STORE_NAME_HERE"
+    }
+
+}

--- a/src/ServerScriptService/Managers/SaveManager/init.luau
+++ b/src/ServerScriptService/Managers/SaveManager/init.luau
@@ -5,28 +5,66 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Achievements = require(ReplicatedStorage.Assets.Achievements)
 local Utils = require(ReplicatedStorage.Modules.Utils)
 
+
+-- The module has two tables inherently:
+--	PlayerDatas holds the unmodified tables that are grabbed from the datastore and turned into a tree of valueobjects. 
+-- 	PlayerLeaderstatConns holds references to the event listeners watching over certain stats that are tracked by the leaderboard, so they can be disconnected when the player leaves, to avoid a memory leak.
 local SaveManager = {
 	PlayerDatas = {},
 	PlayerLeaderstatConns = {},
 }
 
+
 local Storage
 local Attempt = 0
 
+-- An attempt to fix constantly having to go back to this script and re-set your datastore name and key whenever the SaveManager updates.
+-- These objects are parented to the SaveManager script. Place your datastore name and key in them, and it should never require you to go back and set them again, since those objects will not be updated as frequently as this script here.
+-- You can modify the objects in Roblox Studio, or modify it in VSC by modifying the .model.json files adjacent to this script in src/ServerScriptService/Managers/SaveManager/DataStoreRef.model.json and src/ServerScriptService/Managers/SaveManager/DataStoreKey.model.json.
+local DataStoreHolder = script:FindFirstChild("DataStoreRef")
+local DataStoreKeyHolder = script:FindFirstChild("DataStoreKey")
+
+local DataStoreRef = DataStoreHolder.Value 
+if not DataStoreRef or DataStoreRef == "DATA_STORE_NAME_HERE" then
+	warn("[SaveManager] – WARNING: Datastore name not set!")
+	warn("Place the name of your datastore in ServerScriptService/Managers/SaveManager/DataStoreRef in Roblox Studio, or in src/ServerScriptService/Managers/SaveManager/DataStoreRef.model.json in Visual Studio Code.")
+	warn("You should only need to do this once– if this happens frequently, contact a Dysymmetrical developer.\n")
+	DataStoreRef = "Baleful" -- Dysymmetrical default datastore for testing purposes.
+end
+
+local DataStoreKey = DataStoreKeyHolder.Value
+if not DataStoreKey or DataStoreKey == "DATA_STORE_KEY_HERE" then
+	warn("[SaveManager] – WARNING: Key for datastore '"..DataStoreRef.."' not set!")
+	warn("Make sure you have the key of your datastore in ServerScriptService/Managers/SaveManager/DataStoreKey in Roblox Studio, or in src/ServerScriptService/Managers/SaveManager/DataStoreKey.model.json in Visual Studio Code.")
+	warn("Hopefully, you should only need to do this once– if this message appears frequently, contact a Dysymmetrical developer.\n")
+	DataStoreRef = "baleful" -- Dysymmetrical default datastore for testing purposes.
+end
+
+
 -- Will retry retrieving data again and again until it finally succeeds. Datastores are too unreliable to be one-and-done, and may otherwise corrupt data.
+-- We don't want to defer this– if files are attempted to be grabbed from the datastore before the datastore loads... That'll be, ah, not good.
 repeat 
 	Attempt += 1
 
 	_, Storage = pcall(function()
-		return DataStoreService:GetDataStore("Baleful") -- PLACE YOUR DATASTORE HERE
+		return DataStoreService:GetDataStore(DataStoreRef) 
 	end)
 until Storage or Attempt > 50
 
+local StoreKey = DataStoreKey 
 
-local StoreKey = "baleful" -- PLACE YOUR DATASTORE KEY HERE
 
 
---- Organizes a hiearchy of instances and valueobjects into a table
+
+
+
+--[[
+	Function for converting a ValueObject tree into a table.
+
+	Used to turn the valueobjects used to store playerdata into a format we can save to the datastore.
+
+	Eventually, this will probably be made two-way, and more functionality may be added to it.
+]]--
 local function ConvertInstanceTreeToTable(TargetInstance: Instance, Depth: number?): ({[string]: {any}}) -- Can return a table of string-value pairs which can be arbitrarily deep, dont quite know how to define that for the typechecker, so just do your best (as always!).
 
 	local tree = {}
@@ -42,7 +80,7 @@ local function ConvertInstanceTreeToTable(TargetInstance: Instance, Depth: numbe
 	for _index, value in ipairs(TargetInstance:GetChildren()) do
 
 		-- If the child is a folder, run this function again on it to create another nest.
-		if value:IsA("Folder") and Depth < 50 then -- Customize the depth cap as you please. Realistically, nothing will ever go this deep, but you can never be too sure...
+		if value:IsA("Folder") and Depth < 50 then -- Customize the depth cap as you please. Realistically, nothing will ever go this deep, but to avoid a permanant hang or an infinite loop, you can never be too sure...
 
 			tree[value.Name] = ConvertInstanceTreeToTable(value, Depth)
 
@@ -58,171 +96,193 @@ local function ConvertInstanceTreeToTable(TargetInstance: Instance, Depth: numbe
 end
 
 
+
 --- Sets up save data handlers, listens for players joining and leaving to read, write, retrieve, and store save data.
 function SaveManager:Init()
 
-	-- Load a player's data when they join, and additionally retrieve and load all players that may have been in the game before this runs. Feels like that'd be rare, but I suppose one never knows...
+	-- Validate the default values for playerdata, and make sure they point to killers/survivors that exist. If killers/survivors are moved and this isn't updated, new players could otherwise get an invalid killer/survivor, and become softlocked.
+	-- We *want* the game to hang for a bit to check these, since new players wont be able to join the game if it's malformed.
+
+	-- First, check to make sure the valueobjects which these would be stored in exist.
+
+	-- Quickly flip through and make sure the valueobjects we need exist. Eventually may create them on its own, to make things easier.
+	if not (script.PlayerData and script.PlayerData.Equipped and script.PlayerData.Equipped.Killer and script.PlayerData.Equipped.Survivor and script.PlayerData.Purchased and script.PlayerData.Purchased.Killers and script.PlayerData.Purchased.Skins and script.PlayerData.Purchased.Survivors) then
+		error("[SaveManager:Init()] – ERROR: Default playerdata may be missing important pieces, or entirely absent! Check for a folder in ServerScriptService/Managers/SaveManager/PlayerData. If you know what you're doing, you can silence this message in ServerScriptService/Managers/SaveManager.")
+	end
+
+	local Playerdata = script.PlayerData
+	local EquippedFolder = Playerdata.Equipped
+	local PurchasedFolder = Playerdata.Purchased
+
+	-- Check if the listed default killer still exists
+	local DefaultKiller = EquippedFolder.Killer.Value
+	local KillerModule = Utils.Instance.GetCharacterModule("Killer", DefaultKiller)
+
+	-- If the default killer points to a killer who doesn't exist anymore, grab the first one the game can find and use that as the default instead.
+	if not KillerModule then
+
+		local AllKillers = ReplicatedStorage:FindFirstChild("Characters"):FindFirstChild("Killers"):GetChildren()
+
+		-- Set the default equipped killer to the first killer found in this list as a temporary, non-error-prone solution. This can be changed by the user to another killer, and the game wont try to do this again unless the killer this value points to doesn't exist again.
+		EquippedFolder.Killer.Value = AllKillers[1].Name
+
+		-- "This could technically error if no killers are found, but if such is the case, I think the developer has bigger errors to worry about, so I think its fine to leave it as-is" – Itred
+
+		warn("[SaveManager:Init()] – INFO: Default (template) playerdata points to a killer which no longer exists. Substituting with '"..AllKillers[1].Name.."' for now. \nModify the value in 'ServerScriptService/Managers/SaveManager/PlayerData/Equipped/Killer' if you wish to set a different default killer.")
+
+	end
+
+
+	-- Check if the listed default survivors still exists
+	local DefaultSurvivor = EquippedFolder.Survivor.Value
+	local SurvivorModule = Utils.Instance.GetCharacterModule("Survivor", DefaultSurvivor)
+
+	-- Same deal for survivors– If the default survivor points to one whom doesn't exist anymore, grab the first one the game can find and use that as the default instead.
+	if not SurvivorModule then
+
+		local AllSurvivors = ReplicatedStorage:FindFirstChild("Characters"):FindFirstChild("Survivors"):GetChildren()
+
+		-- Similarly, set the default equipped survivor to the first survivor found in this list as a temporary, non-error-prone solution. This can be changed by the user to another survivor, and the game wont try to do this again unless the survivor this value points to doesn't exist again.
+		EquippedFolder.Survivor.Value = AllSurvivors[1].Name
+
+		-- "This, too, could technically error if no survivors are found, but if such is the case, what are you even doing." – Itred
+
+		warn("[SaveManager:Init()] – INFO: Default (template) playerdata points to a survivor which no longer exists. Substituting with '"..AllSurvivors[1].Name.."' for now. \nModify the value in 'ServerScriptService/Managers/SaveManager/PlayerData/Equipped/Survivor' if you wish to set a different default survivor.")
+
+	end
+
+
+	-- Also check for the default purchased killer/survivor. Note, however, that this will only apply to the template data, so bought killers by players that are to be replaced later will also be unaffected.
+
+	-- Default purchased killers:
+	for index, purchasedkiller in PurchasedFolder.Killers:GetChildren() do
+
+		-- Find its module.
+		local PurchasedKillerModule = Utils.Instance.GetCharacterModule("Killer", purchasedkiller.Name)
+
+		-- If it doesn't exist, set its name to the default killer instead after just one more check.
+		if not PurchasedKillerModule then
+
+			-- Check to see if theres already a valueobject tied to the default killer. If there isn't, then assume that the sole default purchased killer should match the default killer.
+			if not PurchasedFolder.Killers:FindFirstChild(DefaultKiller) then 
+
+				purchasedkiller.Name = EquippedFolder.Killer.Value -- Re-read from the newly-updated killer value
+				warn("[SaveManager:Init()] – INFO: Default (template) purchased killer doesn't exist. Modifying to match default equipped killer... Change this in 'ServerScriptService/Managers/SaveManager/PlayerData/Purchased/Killer' if you wish to set your own default purchased killer.")
+
+			else
+
+				warn("[SaveManager:Init()] – WARNING: More than one default purchased killer pointed to a character which didn't exist! For stability reasons, these will be temporarily destroyed. Check 'ServerScriptService/Managers/SaveManager/PlayerData/Purchased/Killer' to diagonose any issues.")
+				purchasedkiller:Destroy()
+
+			end
+		end
+	end
+
+
+	-- Default purchased survivors:
+	for index, purchasedsurvivor in PurchasedFolder.Survivors:GetChildren() do
+
+		-- Find its module.
+		local PurchasedSurvivorModule = Utils.Instance.GetCharacterModule("Survivor", purchasedsurvivor.Name)
+
+		-- If it doesn't exist, set its name to the default survivor instead after just one more check.
+		if not PurchasedSurvivorModule then
+
+			-- Same deal as with the killer– Check to see if theres already a valueobject tied to the default survivor. If there isn't, then assume that the sole default purchased survivor should match the default survivor.
+			if not PurchasedFolder.Survivors:FindFirstChild(DefaultSurvivor) then 
+
+				purchasedsurvivor.Name = EquippedFolder.Survivor.Value -- Re-read from the newly-updated survivor value
+				warn("[SaveManager:Init()] – INFO: Default purchased killer doesn't exist. Modifying to match default equipped killer... Change this in 'ServerScriptService/Managers/SaveManager/PlayerData/Purchased/Killer' if you wish to set your own default purchased killer.")
+
+			else
+
+				warn("[SaveManager:Init()] – WARNING: More than one default purchased killer pointed to a character which didn't exist! For stability reasons, these will be temporarily destroyed. Check 'ServerScriptService/Managers/SaveManager/PlayerData/Purchased/Killer' to diagonose any issues.")
+				purchasedsurvivor:Destroy()
+
+			end
+		end
+	end
+
+
+
+	-- Watches for players joining the game through a custom version of Players.PlayerAdded. See in Utils.Player for more information..
 	Utils.Player.ObservePlayers(function(Player: Player)
-
-		-- Grab the player's data from the datastore, place it into a table for later use 
-		self.PlayerDatas[Player.UserId] = self:Load(Player)
-		local ThisPlayerData = self.PlayerDatas[Player.UserId] -- Gets its own variable to make things easier to read. Done in this way so this variable points to the entry in the table and not to the data itself.
-
-
-		-- Go through all achievements, set them up in folders for the player in question.
-		for AchievementGroupCodeName, AchievementGroup in Achievements do
-
-			-- If the specific achievement group doesnt exist, make it.
-			if not ThisPlayerData.Achievements:FindFirstChild(AchievementGroupCodeName) then
-
-				local Group = Instance.new("Folder")
-				Group.Name = AchievementGroupCodeName
-				Group.Parent = ThisPlayerData.Achievements
-
-			end
-
-			-- Go by achievement group, check for achievement-tracking valueobjects.
-			for AchievementCodeName, Achievement in AchievementGroup do
-
-				-- If the valueobject for tracking this achievement's progress doesn't exist, make it.
-				if Achievement.Requirement and not ThisPlayerData.Achievements[AchievementGroupCodeName]:FindFirstChild(AchievementCodeName) then
-
-					local AchievementProgress = Instance.new("NumberValue")
-					AchievementProgress.Name = AchievementCodeName
-					AchievementProgress.Value = 0
-					AchievementProgress.Parent = ThisPlayerData
-
-				end
-
-			end
-
-		end
-	end)
-
-	-- Ensure default values for playerdata doing point to killers/survivors that exist. First, check to make sure the valueobjects which these would be stored in exist.
-	-- spawn to execute it as soon as possible
-	task.spawn(function()
-		-- Yeah, its a lot of checks, but it has to be thorough. -itred
-		-- it may be a lot of checks but they're only done once so suck it! 🗣️ -dys
 		
-		if not (script.PlayerData and script.PlayerData.Equipped and script.PlayerData.Equipped.Killer and script.PlayerData.Equipped.Survivor and script.PlayerData.Purchased and script.PlayerData.Purchased.Killers and script.PlayerData.Purchased.Skins and script.PlayerData.Purchased.Survivors) then
-			warn("[SaveManager:Init()]: WARNING – Default playerdata may be missing important pieces, or entirely absent! Check for a folder in ServerScriptService/Managers/SaveManager/PlayerData. If you know what you're doing, you can ignore or silence this message.")
-			return
-		end
+		-- Go through players in parallel, rather than one-by-one.
+		task.defer(function()
 
-		local Playerdata = script.PlayerData
-		local EquippedFolder = Playerdata.Equipped
-		local PurchasedFolder = Playerdata.Purchased
-
-		-- Check the default killer
-		local DefaultKiller = EquippedFolder.Killer.Value
-		local KillerModule = Utils.Instance.GetCharacterModule("Killer", DefaultKiller)
-
-		-- If the default killer points to a killer who doesn't exist anymore, grab the first one the game can find and use that as the default instead.
-		if not KillerModule then
-
-			local AllKillers = ReplicatedStorage:FindFirstChild("Characters"):FindFirstChild("Killers"):GetChildren()
-
-			-- Set the default equipped killer to the first killer found in this list as a temporary, non-error-prone solution. This can be changed by the user to another killer, and the game wont try to do this again unless the killer this value points to doesn't exist again.
-			EquippedFolder.Killer.Value = AllKillers[1].Name
-
-			-- "This could technically error if no killers are found, but if such is the case, I think the developer has bigger errors to worry about, so I think its fine to leave it as-is" – Itred
-
-			warn("[SaveManager:Init()]: INFO – Default (template) playerdata points to a killer which no longer exists. Substituting with '"..AllKillers[1].Name.."' for now. \nModify the value in 'ServerScriptService/Managers/SaveManager/PlayerData/Equipped/Killer' if you wish to set a different default killer.")
-
-		end
+			-- Grab the player's data from the datastore, place it into a table for later use 
+			self.PlayerDatas[Player.UserId] = self:Load(Player)
+			local ThisPlayerData = self.PlayerDatas[Player.UserId] -- Gets its own variable to make things easier to read. Done in this way so this variable points to the entry in the table and not to the data itself.
 
 
-		-- Check the default survivor
-		local DefaultSurvivor = EquippedFolder.Survivor.Value
-		local SurvivorModule = Utils.Instance.GetCharacterModule("Survivor", DefaultSurvivor)
+			-- Go through all achievements, set them up in folders for the player in question.
+			for AchievementGroupCodeName, AchievementGroup in Achievements do
 
-		-- Same deal for survivors– If the default survivor points to one whom doesn't exist anymore, grab the first one the game can find and use that as the default instead.
-		if not SurvivorModule then
+				-- If the specific achievement group doesnt exist, make it.
+				if not ThisPlayerData.Achievements:FindFirstChild(AchievementGroupCodeName) then
 
-			local AllSurvivors = ReplicatedStorage:FindFirstChild("Characters"):FindFirstChild("Survivors"):GetChildren()
-
-			-- Similarly, set the default equipped survivor to the first survivor found in this list as a temporary, non-error-prone solution. This can be changed by the user to another survivor, and the game wont try to do this again unless the survivor this value points to doesn't exist again.
-			EquippedFolder.Survivor.Value = AllSurvivors[1].Name
-
-			-- "This, too, could technically error if no survivors are found, but if such is the case, what are you even doing." – Itred
-
-			warn("[SaveManager:Init()]: INFO – Default (template) playerdata points to a survivor which no longer exists. Substituting with '"..AllSurvivors[1].Name.."' for now. \nModify the in value 'ServerScriptService/Managers/SaveManager/PlayerData/Equipped/Survivor' if you wish to set a different default survivor.")
-
-		end
-
-
-		-- Also check for the purchased killer/survivor. Note, however, that this will only apply to the template data, so bought killers by players that are to be replaced later will also be unaffected.
-
-		-- Default purchased killers:
-		for index, purchasedkiller in PurchasedFolder.Killers:GetChildren() do
-
-			-- Find its module.
-			local PurchasedKillerModule = Utils.Instance.GetCharacterModule("Killer", purchasedkiller.Name)
-
-			-- If it doesn't exist, set its name to the default killer instead after just one more check.
-			if not PurchasedKillerModule then
-
-				-- Check to see if theres already a valueobject tied to the default killer. If there isn't, then assume that the sole default purchased killer should match the default killer.
-				if not PurchasedFolder.Killers:FindFirstChild(DefaultKiller) then 
-
-					purchasedkiller.Name = EquippedFolder.Killer.Value -- Re-read from the newly-updated killer value
-					warn("[SaveManager:Init()]: INFO – Default purchased killer doesn't exist. Modifying to match default equipped killer... Change this in 'ServerScriptService/Managers/SaveManager/PlayerData/Purchased/Killer' if you wish to set your own default purchased killer.")
-
-				else
-
-					warn("[SaveManager:Init()]: WARNING – More than one default purchased killer pointed to a character which didn't exist! For stability reasons, these will be temporarily destroyed. Check 'ServerScriptService/Managers/SaveManager/PlayerData/Purchased/Killer' to diagonose any issues.")
-					purchasedkiller:Destroy()
+					local Group = Instance.new("Folder")
+					Group.Name = AchievementGroupCodeName
+					Group.Parent = ThisPlayerData.Achievements
 
 				end
-			end
-		end
 
+				-- Go by achievement group, check for achievement-tracking valueobjects.
+				for AchievementCodeName, Achievement in AchievementGroup do
 
-		-- Default purchased survivors:
-		for index, purchasedsurvivor in PurchasedFolder.Survivors:GetChildren() do
+					-- If the valueobject for tracking this achievement's progress doesn't exist, make it.
+					if Achievement.Requirement and not ThisPlayerData.Achievements[AchievementGroupCodeName]:FindFirstChild(AchievementCodeName) then
 
-			-- Find its module.
-			local PurchasedSurvivorModule = Utils.Instance.GetCharacterModule("Survivor", purchasedsurvivor.Name)
+						local AchievementProgress = Instance.new("NumberValue")
+						AchievementProgress.Name = AchievementCodeName
+						AchievementProgress.Value = 0
+						AchievementProgress.Parent = ThisPlayerData
 
-			-- If it doesn't exist, set its name to the default survivor instead after just one more check.
-			if not PurchasedSurvivorModule then
-
-				-- Same deal as with the killer– Check to see if theres already a valueobject tied to the default survivor. If there isn't, then assume that the sole default purchased survivor should match the default survivor.
-				if not PurchasedFolder.Survivors:FindFirstChild(DefaultSurvivor) then 
-
-					purchasedsurvivor.Name = EquippedFolder.Survivor.Value -- Re-read from the newly-updated survivor value
-					warn("[SaveManager:Init()]: INFO – Default purchased killer doesn't exist. Modifying to match default equipped killer... Change this in 'ServerScriptService/Managers/SaveManager/PlayerData/Purchased/Killer' if you wish to set your own default purchased killer.")
-
-				else
-
-					warn("[SaveManager:Init()]: WARNING – More than one default purchased killer pointed to a character which didn't exist! For stability reasons, these will be temporarily destroyed. Check 'ServerScriptService/Managers/SaveManager/PlayerData/Purchased/Killer' to diagonose any issues.")
-					purchasedsurvivor:Destroy()
+					end
 
 				end
+
 			end
-		end
+
+		end)
+		
 	end)
+
 
 	-- Save a player's data when they leave the game.
 	Players.PlayerRemoving:Connect(function(Player: Player)
-		if self.PlayerLeaderstatConns[Player.UserId] then
-			self.PlayerLeaderstatConns[Player.UserId]:Disconnect()
-		end
-		self:Save(Player, self.PlayerDatas[Player.UserId])
+		-- Deferred so it'll save playerdata parallel, instead of doing so one-at-a-time.
+		task.defer(function()
+
+			if self.PlayerLeaderstatConns[Player.UserId] then
+				self.PlayerLeaderstatConns[Player.UserId]:Disconnect()
+			end
+
+			self:Save(Player, self.PlayerDatas[Player.UserId])
+
+		end)
 	end)
+
 
 	-- Mark some global saving code to be run if the server gets manually closed for one reason or another.
 	game:BindToClose(function()
 		for _, i in Players:GetPlayers() do
-			self:Save(i, self.PlayerDatas[i.UserId])
+			-- Deferred so it can save every player, rather than going through and saving them one-by-one.
+			task.defer(function()
+
+				self:Save(i, self.PlayerDatas[i.UserId])
+
+			end)
+
 		end
 	end)
+
 end
 
 
---- Sets up a display leaderstat folder for any data that has the `DisplayInLeaderstats` attribute.
-function SaveManager:_SetupLeaderStats(DataFolder, parent) --just for display, won't save
+--- Sets up folder for any data that has the `DisplayInLeaderstats` attribute, to display them on the leaderboard.
+function SaveManager:_SetupLeaderStats(DataFolder, parent) -- Uses its own function, so it doesn't save. 
 
 	for _, data in DataFolder:GetDescendants() do
 
@@ -243,7 +303,10 @@ function SaveManager:_SetupLeaderStats(DataFolder, parent) --just for display, w
 	end
 end
 
+
 --- Loads a player's savedata and generates a heirarchy of folders and valuebase objects for storing, reading, and writing to and from it in-game.
+--- 
+--- ### DEFER ANY CALLS TO THIS FUNCTION, IT MAY TAKE A WHILE.
 function SaveManager:Load(Player: Player): Folder
 
 	-- Retrieve playerdata
@@ -261,10 +324,10 @@ function SaveManager:Load(Player: Player): Folder
 			
 			task.wait()
 		-- do few attempts just in case it's a new player
-		until PlayerData or Attempt > 7
+		until PlayerData or Attempt > 10
 
 	else    
-		warn("[SaveManager:Init()]: WARNING – ENTIRE DATASTORE failed to load. Handling playerdata from here is extremely hazardous. Here be dragons!")
+		warn("[SaveManager:Load()]: FATAL ERROR – ENTIRE DATASTORE failed to load. Handling playerdata from here is extremely hazardous. Here be dragons!")
 	end
 
 	local ClonedData = script.PlayerData:Clone()
@@ -342,6 +405,7 @@ function SaveManager:Load(Player: Player): Folder
 			int.Name = emotename
 		end
 
+
 		-- killers,
 		for killer, level in PlayerData.Purchased.Killers do
 
@@ -360,6 +424,7 @@ function SaveManager:Load(Player: Player): Folder
 
 		end
 
+
 		-- survivors,
 		for survivor, level in PlayerData.Purchased.Survivors do
 
@@ -376,6 +441,7 @@ function SaveManager:Load(Player: Player): Folder
 			end
 			int.Name = survivor
 		end
+
 
 		-- skins,
 		for skinname, skindata in PlayerData.Purchased.Skins do
@@ -407,6 +473,7 @@ function SaveManager:Load(Player: Player): Folder
 
 		end
 
+
 		-- applied settings,
 		for _index, setting in PlayerData.Settings do
 
@@ -418,6 +485,7 @@ function SaveManager:Load(Player: Player): Folder
 			end
 
 		end
+
 
 		-- and tracked stats.
 		for _index, stat in PlayerData.Stats do
@@ -431,6 +499,7 @@ function SaveManager:Load(Player: Player): Folder
 
 		end
 
+
 	end
 	-- self:_CheckCheckSaveIntegrity(ClonedData)
 
@@ -443,7 +512,8 @@ function SaveManager:Load(Player: Player): Folder
 end
 
 
---- Saves a given player's data.
+
+--- Saves a given player's data. **Defer any calls to this function– it may take a while.**
 function SaveManager:Save(Player: Player, Data: Folder)
 	local SaveFile = ConvertInstanceTreeToTable(Data)
 


### PR DESCRIPTION
From commit:
> SaveManager now defers to a parallel function when loading and saving playerdata, which should fix new players holding up everyone else, and taking a ridiculously long time to load.
>
> SaveManager now reads the datastore name and key from a valueobject stored underneath it. This is so developers using the engine wont need to keep going into the SaveManager and placing their datastore name and key in it whenever it updates, and they can instead add that to the (relatively static) objects parented to the module.
>
> Minor grammar/clarity changes on code comments in SaveManager.
>
> Minor grammar/clarity changes to warnings SaveManager can spit out.


As always, let me know if there is anything I missed.

Cheers,
- Itred