### PR TITLE
Improved hitbox wall checking and fixed BaseSpeed not being set.

### DIFF
--- a/src/ReplicatedStorage/Classes/Hitbox.luau
+++ b/src/ReplicatedStorage/Classes/Hitbox.luau
@@ -218,7 +218,9 @@ function Hitbox.New(SourcePlayer: Player, Config: Types.HitboxSettings): Types.H
                             or (collidedpart.Parent:FindFirstChild("Role") and collidedpart.Parent.Role.Value or Char.Role.Value)
                         ) ~= Char.Role.Value) then
                     continue
-                end
+				end
+				
+				--[[
                 -- If the hitbox has no preset anchor, the anchor its using is the HumanoidRootPart of the user– perform some sanity checks to ensure the target isn't getting hit through a wall or similar.
                 if not Config.CFrame then
 
@@ -243,6 +245,33 @@ function Hitbox.New(SourcePlayer: Player, Config: Types.HitboxSettings): Types.H
                         continue
                     end
                 end
+                ]]
+				
+				-- Check if there's a wall between player and target
+				if not Config.CFrame then
+					local HRoot = collidedpart.Parent:FindFirstChild("HumanoidRootPart")
+					if HRoot then
+						local function isBlockedByObstacle(): boolean
+							for _, offset in {-2, 0, -2} do
+								local origin = Root.Position + Vector3.yAxis * offset
+								local target = HRoot.Position + Vector3.yAxis * offset
+								local cast = workspace:Raycast(origin, target - origin, RayParams)
+								
+								if cast
+									and not cast.Instance:IsDescendantOf(collidedpart.Parent)
+									and cast.Instance.Transparency ~= 1
+									and not cast.Instance:GetAttribute("Hitbox") then
+									return true
+								end
+							end
+							return false
+						end
+						
+						if isBlockedByObstacle() then
+							continue
+						end
+					end
+				end
 
                 -- Otherwise, add the player to two different tracking tables.
                 table.insert(Props.HumanoidsHit, Humanoid)

--- a/src/ServerScriptService/Managers/PlayerManager/PlayerSpeedManager.luau
+++ b/src/ServerScriptService/Managers/PlayerManager/PlayerSpeedManager.luau
@@ -24,10 +24,33 @@ function PlayerSpeedManager:Init()
                     return
                 end
 
-                local CurrentSpeed = Character:GetAttribute("BaseSpeed")
+                --[[local CurrentSpeed = Character:GetAttribute("BaseSpeed")
                 if CurrentSpeed == nil then
                     CurrentSpeed = 10.5
-                end
+                end]]
+				
+				local CurrentSpeed = Character:GetAttribute("BaseSpeed")
+				if CurrentSpeed == nil then
+					local fallBackSpeed = 10.5
+					local charName = Character:GetAttribute("CharacterName")
+					local charSkin = Character:GetAttribute("CharacterSkinName")
+					local roleValue
+					if Character:FindFirstChild("Role") then
+						roleValue = Character.Role.Value
+					end
+					
+					if roleValue and charName and #charName > 0 then
+						local moduleInstance = Utils.Instance.GetCharacterModule(roleValue, charName, charName)
+						if moduleInstance then
+							local success, mod = pcall(require, moduleInstance)
+							if success and mod.GameplayConfig and type(mod.GameplayConfig.BaseSpeed) == "number" then
+								fallBackSpeed = mod.GameplayConfig.BaseSpeed
+							end
+						end
+					end
+					
+					CurrentSpeed = fallBackSpeed
+				end
 
                 local TotalFactor = 1
                 for _, factor in PlayerSpeedManager.ManagedPlayers[Player].Factors do

--- a/src/ServerScriptService/Managers/PlayerManager/init.luau
+++ b/src/ServerScriptService/Managers/PlayerManager/init.luau
@@ -58,8 +58,30 @@ function PlayerManager:Init()
 			
 			local Role = char:FindFirstChild("Role")
 
-			if char:GetAttribute("BaseSpeed") == nil then
+			--[[if char:GetAttribute("BaseSpeed") == nil then
 				char:SetAttribute("BaseSpeed", 10.5)
+			end]]
+			
+			if char:GetAttribute("BaseSpeed") == nil then
+				local defaultSpeed = 10.5
+				local charName = char:GetAttribute("CharacterName")
+				local charSkin = char:GetAttribute("CharacterSkinName")
+				local roleValue
+				if char:FindFirstChild("Role") then
+					roleValue = char.Role.Value
+				end
+				
+				if roleValue and charName and #charName > 0 then
+					local moduleInstance = Utils.Instance.GetCharacterModule(roleValue, charName, charName)
+					if moduleInstance then
+						local success, mod = pcall(require, moduleInstance)
+						if success and mod.GameplayConfig and type(mod.GameplayConfig.BaseSpeed) == "number" then
+							defaultSpeed = mod.GameplayConfig.BaseSpeed
+						end
+					end
+				end
+				
+				char:SetAttribute("BaseSpeed", defaultSpeed)
 			end
 
 			char.Parent = PlayerFolder


### PR DESCRIPTION
Heya Dyscarn, I made these changes for my game to fix hitbox going through walls when facing away from it and also fixed `BaseSpeed` not being set as it was only defaulting to `10.5` resulting in the config being practically useless.

Made this pull request so these fixes can be applied to other games as well. If there's any improvements you can make, feel free to do so.