### PR TITLE
Quick hitbox wall checking adjustment and Instance highlighting

### DIFF
--- a/src/ReplicatedStorage/Classes/Hitbox.luau
+++ b/src/ReplicatedStorage/Classes/Hitbox.luau
@@ -261,7 +261,7 @@ function Hitbox.New(SourcePlayer: Player, Config: Types.HitboxSettings): Types.H
                 ]]
 
 				-- Check if there's a wall between player and target
-				if not Config.CFrame and not Config.IgnoreWalls then
+				if not Config.IgnoreWalls then
 					local HRoot = Humanoid.Parent:FindFirstChild("HumanoidRootPart")
 					if HRoot then
 						local function isBlockedByObstacle(): boolean

--- a/src/ReplicatedStorage/Modules/Utils/InstanceUtils.luau
+++ b/src/ReplicatedStorage/Modules/Utils/InstanceUtils.luau
@@ -5,6 +5,11 @@ local Types = require(ReplicatedStorage.Classes.Types)
 local TypeUtils = require(script.Parent.TypeUtils)
 local Janitor = require(ReplicatedStorage.Packages.Janitor)
 
+local RunService = game:GetService("RunService")
+local Debris = game:GetService("Debris")
+local TweenService = game:GetService("TweenService")
+local Network = require(ReplicatedStorage.Modules.Network)
+
 local InstanceUtils = {}
 
 --- Equivalent of `Instance.ChildAdded:Connect()` but managed by Janitor.
@@ -369,6 +374,60 @@ function InstanceUtils.GetInvisPart(cf: CFrame?, parent: Instance?): Part
     end
 
     return Part
+end
+
+--- CLIENT FUNCTION: Highlights an instance for the local player
+function InstanceUtils.HighlightInstance(instance: Instance, duration: number?, color: Color3?)
+	if RunService:IsServer() then return end
+	if not instance or not instance:IsDescendantOf(workspace) then return end
+
+	local existingHighlight = instance:FindFirstChild("InstanceHighlight")
+	if existingHighlight then
+		existingHighlight:Destroy()
+	end
+
+	local usedColor = color or Color3.fromRGB(255, 255, 255)
+	local usedDuration = duration or 10
+
+	local highlight = Instance.new("Highlight")
+	highlight.Name = "InstanceHighlight"
+	highlight.FillColor = usedColor
+	highlight.OutlineColor = usedColor
+	highlight.Parent = instance
+
+	Debris:AddItem(highlight, usedDuration + 2)
+
+	-- Fade in
+	highlight.FillTransparency = 1
+	highlight.OutlineTransparency = 1
+	TweenService:Create(highlight, TweenInfo.new(1), {
+		FillTransparency = 0.5,
+		OutlineTransparency = 0
+	}):Play()
+
+	-- Fade out before destruction
+	task.delay(usedDuration - 1, function()
+		if highlight and highlight.Parent then
+			highlight.Name = "FadingOut"
+			TweenService:Create(highlight, TweenInfo.new(1), {
+				FillTransparency = 1,
+				OutlineTransparency = 1
+			}):Play()
+		end
+	end)
+end
+
+--- SERVER FUNCTION: Highlights an instance for specific player(s)
+function InstanceUtils.HighlightInstanceFor(players: Player | {Player}, instance: Instance, duration: number?, color: Color3?)
+	if not RunService:IsServer() then return end
+
+	if typeof(players) == "table" then
+		for _, player in players do
+			Network:FireClientConnection(player, "HighlightInstance", "REMOTE_EVENT", instance, duration, color)
+		end
+	else
+		Network:FireClientConnection(players, "HighlightInstance", "REMOTE_EVENT", instance, duration, color)
+	end
 end
 
 return InstanceUtils

--- a/src/ReplicatedStorage/Modules/Utils/init.luau
+++ b/src/ReplicatedStorage/Modules/Utils/init.luau
@@ -84,7 +84,11 @@ function Utils:Init()
         end)
         Network:SetConnection("ShakeCamera", "REMOTE_EVENT", function(Magnitude: number, Duration: number)
             return Utils.Player.ShakeCamera(Magnitude, Duration)
-        end)
+		end)
+		
+		Network:SetConnection("HighlightInstance", "REMOTE_EVENT", function(instance: Instance, duration: number?, color: Color3?)
+			Utils.Instance.HighlightInstance(instance, duration, color)
+		end)
 
         return
     end


### PR DESCRIPTION
Quick PR to adjust the wall checks in the hitbox. Before, if you put a `CFrame` variable in the hitbox, it skips the wall check entirely. Now, we just check for `IgnoreWalls` so it's way simpler and more consistent.